### PR TITLE
feat: add an optional 12-hour format, delete Miduconf default date

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,16 +11,21 @@
   <body class="toast">
     <wc-toast></wc-toast>
     <main class="container">
+      <label>
+        <input type="checkbox" id="date-format" role="switch">
+        Usar formato de 12 horas.
+      </label>
+
       <form>
         <label>
           Selecciona una fecha y una hora:
-          <input name="date" type="datetime-local" value="2022-09-13T17:00" />
+          <input id="date-time" name="date" type="datetime-local" />
         </label>
       </form>
 
       <label>
         Resultado:
-        <textarea rows="5" readonly placeholder="Aquí aparece el resultado..."></textarea>
+        <textarea rows="6" readonly placeholder="Aquí aparece el resultado..."></textarea>
       </label>
 
 

--- a/main.js
+++ b/main.js
@@ -15,21 +15,28 @@ function changeTimeZone (date, timeZone) {
   }))
 }
 
-const transformDateToString = (date) => {
-  const localDate = date.toLocaleString('es-ES', {
-    hour12: false,
+const transformDateToString = (date, dateFormat) => {
+  const localCode = dateFormat ? 'en-US' : 'es-Es'
+  const localDate = date.toLocaleString(localCode, {
+    hour12: dateFormat,
     hour: 'numeric',
     minute: 'numeric'
   })
 
-  return localDate.replace(':00', 'H')
+  if (dateFormat && localDate.includes(':00')) return localDate.replace(':00', '').padStart(5, '0')
+  if (dateFormat && !localDate.includes(':00')) return localDate.padStart(8, '0')
+  if (!dateFormat && localDate.includes(':00')) return localDate.replace(':00', ' H').padStart(4, '0')
+
+  return (`${localDate} H`).padStart(7, '0')
 }
 
-const $input = $('input')
+const $input = $('#date-time')
 const $textarea = $('textarea')
+const $switch = $('#date-format')
 
 $input.addEventListener('change', () => {
   const date = $input.value
+  const dateFormat = $switch.checked
 
   const mainDate = new Date(date)
 
@@ -63,7 +70,7 @@ $input.addEventListener('change', () => {
     const [country] = countries
     const { date } = country
 
-    return `${transformDateToString(date)} ${flags}`
+    return `${transformDateToString(date, dateFormat)} ${flags}`
   }).join('\n')
 
   // copiamos en el portapapeles el código

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
 body {
   font-family: "Twemoji Country Flags", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
+form {
+  margin-top: 2rem;
+}

--- a/utils.js
+++ b/utils.js
@@ -26,5 +26,5 @@ export const setInitialDate = () => {
   const iso = localDate.toISOString().slice(0, 16) // keep the first 16 chars (YYYY-MM-DDTHH:mm)
   // console.log(iso) -> '2022-08-31T22:00'
 
-  $('input').value = iso
+  $('#date-time').value = iso
 }


### PR DESCRIPTION
- Se añadió un switch para poder usar un formato de 12 horas.
- Se eliminó el fecha por defecto de la Miduconf en el `input`, ya toma la hora actual automaticamente.
https://github.com/midudev/midu-timeszones-latam/pull/5#issue-1358150860